### PR TITLE
add viniciusdsandrade participant

### DIFF
--- a/participants/viniciusdsandrade.json
+++ b/participants/viniciusdsandrade.json
@@ -1,0 +1,6 @@
+[
+    {
+        "id": "andrade-rust",
+        "repo": "https://github.com/viniciusdsandrade/rinha-de-backend-2026"
+    }
+]


### PR DESCRIPTION
## What changed
Added `participants/viniciusdsandrade.json` with the submission entry for the Rust backend.

## Why
Registers the participant in the official Rinha de Backend 2026 repository using the required filename and JSON array format.

## Impact
The official repo can now discover the submission repository for `andrade-rust`.

## Validation
- `git diff --check`
- verified `participants/viniciusdsandrade.json` format against existing files and `docs/br/SUBMISSAO.md`