### PR TITLE
add viniciusdsandrade participant

### DIFF
--- a/participants/viniciusdsandrade.json
+++ b/participants/viniciusdsandrade.json
@@ -1,0 +1,6 @@
+[
+    {
+        "id": "andrade-rust",
+        "repo": "https://github.com/viniciusdsandrade/rinha-de-backend-2026"
+    }
+]


### PR DESCRIPTION
Adds `participants/viniciusdsandrade.json` with the participant entry for the Rust backend.

Validation: checked the JSON format against the existing participant files and `docs/br/SUBMISSAO.md`.
