### PR TITLE
add: davidalecrim1 rust-extreme participation

### DIFF
--- a/participants/davidalecrim1.json
+++ b/participants/davidalecrim1.json
@@ -1,5 +1,9 @@
 [
   {
+    "id": "davidalecrim1-rust-extreme",
+    "repo": "https://github.com/davidalecrim1/rinha-with-rust-extreme-2026"
+  },
+  {
     "id": "davidalecrim1-rust",
     "repo": "https://github.com/davidalecrim1/rinha-with-rust-2026"
   }


### PR DESCRIPTION
Adds a second submission from davidalecrim1 using a quantized KNN implementation with SSE2 SIMD, targeting the Haswell cache hierarchy.

- Repo: https://github.com/davidalecrim1/rinha-with-rust-extreme-2026
- Image: `davidalecrim1/rinha-rust-extreme-2026:v0.6.0`
- Strategy: 100K reference vectors packed into 16 bytes/row (1.6 MB, fits in Haswell L3), SSE2 `_mm_madd_epi16` for continuous dims, precomputed partial-distance tables for discrete dims