### PR TITLE
chore: swap rust and rust-extreme repo order

### DIFF
--- a/participants/davidalecrim1.json
+++ b/participants/davidalecrim1.json
@@ -1,11 +1,11 @@
 [
   {
-    "id": "davidalecrim1-rust-extreme",
-    "repo": "https://github.com/davidalecrim1/rinha-with-rust-extreme-2026"
-  },
-  {
     "id": "davidalecrim1-rust",
     "repo": "https://github.com/davidalecrim1/rinha-with-rust-2026"
+  },
+  {
+    "id": "davidalecrim1-rust-extreme",
+    "repo": "https://github.com/davidalecrim1/rinha-with-rust-extreme-2026"
   },
   {
     "id": "davidalecrim1-rust-ann",

--- a/participants/davidalecrim1.json
+++ b/participants/davidalecrim1.json
@@ -6,9 +6,5 @@
   {
     "id": "davidalecrim1-rust-extreme",
     "repo": "https://github.com/davidalecrim1/rinha-with-rust-extreme-2026"
-  },
-  {
-    "id": "davidalecrim1-rust-ann",
-    "repo": "https://github.com/davidalecrim1/rinha-with-rust-ann-2026"
   }
 ]


### PR DESCRIPTION
Swap the order of `davidalecrim1-rust` and `davidalecrim1-rust-extreme` entries.