### PR TITLE
chore: prioritize rinha-with-rust-2026 as primary submission for davidalecrim1

### DIFF
--- a/participants/davidalecrim1.json
+++ b/participants/davidalecrim1.json
@@ -1,10 +1,10 @@
 [
   {
-    "id": "davidalecrim1-rust-extreme",
-    "repo": "https://github.com/davidalecrim1/rinha-with-rust-extreme-2026"
-  },
-  {
     "id": "davidalecrim1-rust",
     "repo": "https://github.com/davidalecrim1/rinha-with-rust-2026"
+  },
+  {
+    "id": "davidalecrim1-rust-extreme",
+    "repo": "https://github.com/davidalecrim1/rinha-with-rust-extreme-2026"
   }
 ]


### PR DESCRIPTION
The CI workflow only runs the repo at index 0. Swapping the order so `rinha-with-rust-2026` is tested first.