### PR TITLE
chore: promote davidalecrim1-rust-extreme to index 0 for CI load test

### DIFF
--- a/participants/davidalecrim1.json
+++ b/participants/davidalecrim1.json
@@ -1,10 +1,10 @@
 [
   {
-    "id": "davidalecrim1-rust",
-    "repo": "https://github.com/davidalecrim1/rinha-with-rust-2026"
-  },
-  {
     "id": "davidalecrim1-rust-extreme",
     "repo": "https://github.com/davidalecrim1/rinha-with-rust-extreme-2026"
+  },
+  {
+    "id": "davidalecrim1-rust",
+    "repo": "https://github.com/davidalecrim1/rinha-with-rust-2026"
   }
 ]


### PR DESCRIPTION
The CI workflow only runs the repo at index 0. Moving `davidalecrim1-rust-extreme` to the top so it gets tested.