### PR TITLE
Adds jao.json

### DIFF
--- a/participants/jao.json
+++ b/participants/jao.json
@@ -1,0 +1,4 @@
+[{
+  "id": "jao-go-qdrant",
+  "repo": "https://github.com/jao/rinha-2026-do-bochecha"
+}]


### PR DESCRIPTION
## Descrição / Description

Solução em Go + Qdrant com índice HNSW pré-construído em tempo de build.

O índice vetorial (3M vetores, 14 dimensões) é construído durante o `docker build` sem restrição de CPU, eliminando o tempo de carga em runtime. Na inicialização, o Qdrant carrega o índice do disco em segundos e as duas instâncias de API já estão prontas para servir.

A detecção usa busca HNSW com quantização int8 (always_ram) + rescore float32, o que garante boa precisão sem ler os vetores originais durante a busca.
O rótulo de fraude é codificado no bit 0 do ID do ponto, evitando overhead de payload.

Stack: Go · Qdrant · nginx

## Checklist da submissão / Submission checklist

- [x] 🇧🇷 O total entre os serviços respeita o limite de **1 CPU** e **350MB RAM**<br>🇺🇸 Total across services respects the limit of **1 CPU** and **350MB RAM**
- [x] 🇧🇷 Backend expõe a porta **9999**<br>🇺🇸 Backend exposes port **9999**
- [x] 🇧🇷 Imagens são **linux/amd64**<br>🇺🇸 Images are **linux/amd64**
- [x] 🇧🇷 Rede em modo **bridge**<br>🇺🇸 Network mode is **bridge**
- [x] 🇧🇷 Não usa `network_mode: host` nem `privileged`<br>🇺🇸 Does not use `network_mode: host` nor `privileged`
- [x] 🇧🇷 Possui pelo menos **1 load balancer + 2 APIs**<br>🇺🇸 Has at least **1 load balancer + 2 APIs**
- [x] 🇧🇷 Seu repositório é **público** e contém as branches `main` e `submission`<br>🇺🇸 Your repository is **public** and contains branches `main` and `submission`
- [x] 🇧🇷 Branch `submission` contém na raiz `docker-compose.yml` e `info.json`<br>🇺🇸 Branch `submission` contains `docker-compose.yml` and `info.json` at repo root
