### PR TITLE
Add IsraelAraujo70 asm submission

### DIFF
--- a/participants/IsraelAraujo70.json
+++ b/participants/IsraelAraujo70.json
@@ -2,5 +2,9 @@
     {
         "id": "israelaraujo70-rust",
         "repo": "https://github.com/IsraelAraujo70/rinha-2026"
+    },
+    {
+        "id": "israelaraujo70-asm",
+        "repo": "https://github.com/IsraelAraujo70/rinha-2026-asm"
     }
 ]


### PR DESCRIPTION
Adiciona uma segunda submissão para IsraelAraujo70, mantendo a submissão Rust existente intacta.\n\nNova submissão:\n- id: israelaraujo70-asm\n- repo: https://github.com/IsraelAraujo70/rinha-2026-asm\n\nO repo novo tem branch main com o código-fonte asm e branch submission minimalista com docker-compose.yml, Dockerfile, haproxy.cfg e info.json.