### PR TITLE
feat: add carlosportella16 (Java + Netty + HAProxy)

### DIFF
--- a/participants/carlosportella16.json
+++ b/participants/carlosportella16.json
@@ -1,0 +1,4 @@
+[{
+    "id": "carlosportella16-java",
+    "repo": "https://github.com/carlosportella16/rinha-de-backend-carlosportella16-java"
+}]


### PR DESCRIPTION
## Participant registration

Adding submission for **carlosportella16**.

| Field | Value |
|---|---|
| Participant | Carlos Portella |
| Repo | https://github.com/carlosportella16/rinha-de-backend-carlosportella16-java |
| Stack | Java 25 · Netty · HAProxy |
| Submission branch | [`submission`](https://github.com/carlosportella16/rinha-de-backend-carlosportella16-java/tree/submission) |

### Key implementation details

- **IVF index** — C=1024 clusters, nprobe=8, built at Docker image build time from `references.json.gz`
- **INT8 quantization** — float→byte via `round(f×127)`, 4× memory reduction
- **SoA SIMD (Panama Vector API)** — V5 binary layout stores vectors column-major within blocks of 8; Phase 2 computes distances to 8 candidates simultaneously via `ByteVector.SPECIES_64` + `IntVector.SPECIES_256` (JDK 25 `jdk.incubator.vector`)
- **HAProxy 2.9 + Unix Domain Sockets** — `http-reuse always`, 50ms connect timeout, UDS backend per instance
- **Zero-allocation hot path** — all scratch buffers are `ThreadLocal`, 6 pre-encoded static response `ByteBuf`s
- **JIT warmup** — 10 000 synthetic IVF searches before `READY=true`