### PR TITLE
Add israelaraujo70-meta-gaming submission

### DIFF
--- a/participants/IsraelAraujo70.json
+++ b/participants/IsraelAraujo70.json
@@ -6,5 +6,9 @@
     {
         "id": "israelaraujo70-asm",
         "repo": "https://github.com/IsraelAraujo70/rinha-2026-asm"
+    },
+    {
+        "id": "israelaraujo70-meta-gaming",
+        "repo": "https://github.com/IsraelAraujo70/rinha-2026-meta-gaming"
     }
 ]


### PR DESCRIPTION
Adds a third entry under `participants/IsraelAraujo70.json` for my pure NASM `meta-gaming` submission at https://github.com/IsraelAraujo70/rinha-2026-meta-gaming.

This is the lookup-table variant — keeps my honest `israelaraujo70-asm` (real KNN compute) untouched as a separate entry.