### PR TITLE
add MatheusBasso99 — Crystal (matheus-crystal)

### DIFF
--- a/participants/MatheusBasso99.json
+++ b/participants/MatheusBasso99.json
@@ -1,0 +1,6 @@
+[
+    {
+        "id": "matheus-crystal",
+        "repo": "https://github.com/MatheusBasso99/rinha-de-backend-2026"
+    }
+]


### PR DESCRIPTION
Adiciona `participants/MatheusBasso99.json` com a primeira submissão.

## Submissão

- **id**: `matheus-crystal`
- **repo**: https://github.com/MatheusBasso99/rinha-de-backend-2026
- **stack**: Crystal 1.20.0 + nginx 1.27 alpine
- **imagem pública (linux/amd64)**: `ghcr.io/matheusbasso99/rinha-de-backend-2026:latest`

## Arquitetura

- 1 LB nginx (round-robin puro, sem lógica de negócio) + 2 APIs Crystal — total **1 CPU / 350 MB**, network `bridge`.
- HTTP: `TCPServer` cru + parser HTTP 100% Crystal (zero `picohttpparser`/C deps), keep-alive habilitado.
- JSON: parser zero-alloc próprio (offsets sobre o buffer original).
- Vector search: índice IVF (`k=1024`, `nprobe=16`, top-K=5) com quantização Int16 e triangle-inequality pruning + early-exit decision-aware. `references.bin` (~83 MiB) construído no `docker build` e mmaped na inicialização (`MAP_POPULATE`).
- GC: `GC.disable` após warm-up; hot path zero-alloc.

## Smoke local

`docker compose up` + `k6 run test/test.js` (script oficial deste repo, 120s 1→900 RPS, 54.100 entries):

| métrica | valor |
|---|---|
| p99 | 2.50 ms |
| failure_rate | 0% (FP=1, FN=1, Err=0) |
| score_p99 / score_det | +2602.61 / +2790.31 |
| **final_score** | **+5392.92** |

> Rodado em darwin/arm64 com imagem amd64 emulada — números no Mac Mini oficial podem variar.