### PR TITLE
chore: remove standard rust submission from davidalecrim1

### DIFF
--- a/participants/davidalecrim1.json
+++ b/participants/davidalecrim1.json
@@ -2,9 +2,5 @@
   {
     "id": "davidalecrim1-rust-extreme",
     "repo": "https://github.com/davidalecrim1/rinha-with-rust-extreme-2026"
-  },
-  {
-    "id": "davidalecrim1-rust",
-    "repo": "https://github.com/davidalecrim1/rinha-with-rust-2026"
   }
 ]


### PR DESCRIPTION
Removes the `davidalecrim1-rust` entry, keeping only the extreme variant (`davidalecrim1-rust-extreme`).