### PR TITLE
Adiciona inscrição do participante CaioDGallo (sketchy-node)

### DIFF
--- a/participants/CaioDGallo.json
+++ b/participants/CaioDGallo.json
@@ -2,5 +2,9 @@
     {
         "id": "sketchy-check",
         "repo": "https://github.com/CaioDGallo/sketchy-check"
+    },
+    {
+        "id": "sketchy-node",
+        "repo": "https://github.com/CaioDGallo/sketchy-node"
     }
 ]


### PR DESCRIPTION
Adds the `sketchy-node` entry to my existing `participants/CaioDGallo.json` — a Go + cgo/AVX2 fraud-detection backend, distinct submission from `sketchy-check`.

- repo: https://github.com/CaioDGallo/sketchy-node
- stack: Go, cgo, AVX2/FMA, nginx, IVF k-NN
- image: caiogallo2401/sketchy-node:0.1.0 (linux/amd64, public on Docker Hub)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*