### PR TITLE
Add participant: gabrielrauch (Rust + monoio + IVF)

### DIFF
--- a/participants/gabrielrauch.json
+++ b/participants/gabrielrauch.json
@@ -1,0 +1,6 @@
+[
+  {
+    "id": "rinha-2026-rust",
+    "repo": "https://github.com/gabrielrauch/rinha-2026"
+  }
+]


### PR DESCRIPTION
Adicionando submissão da minha implementação para a Rinha de Backend 2026.

## Stack
- **Rust + monoio** (io_uring no Linux, fallback legacy)
- **IVF** com 2048 centroides + busca k-NN exata em int8 (AVX2 com fallback escalar)
- **HAProxy** round-robin
- Image: `ghcr.io/gabrielrauch/rinha-2026:latest` (publica)

## Repositório
- Source: https://github.com/gabrielrauch/rinha-2026 (branch `main`)
- Submission artifacts: https://github.com/gabrielrauch/rinha-2026/tree/submission