### PR TITLE
add pedrosakuma-dotnet

### DIFF
--- a/participants/pedrosakuma.json
+++ b/participants/pedrosakuma.json
@@ -1,0 +1,6 @@
+[
+  {
+    "id": "pedrosakuma-dotnet",
+    "repo": "https://github.com/pedrosakuma/rinha-backend-2026"
+  }
+]


### PR DESCRIPTION
Adiciona participação **pedrosakuma-dotnet**.

- Stack: .NET 10 NativeAOT + nginx
- Repo: https://github.com/pedrosakuma/rinha-backend-2026
- Imagem: `ghcr.io/pedrosakuma/rinha-backend-2026-api:latest` (linux/amd64, pública)
- Recursos: 1.00 vCPU + 350 MB total
- Branch `submission` contém apenas docker-compose + nginx + info.json conforme especificação.