### PR TITLE
add jfdeev-rust participant

### DIFF
--- a/participants/Jfdeev.json
+++ b/participants/Jfdeev.json
@@ -1,0 +1,4 @@
+[{
+    "id": "jfdeev-rust",
+    "repo": "https://github.com/Jfdeev/rinha-backend-2026"
+}]


### PR DESCRIPTION
🇧🇷 Adiciona o participante `jfdeev-rust` em Jfdeev.json. Backend escrito em Rust com hyper, busca vetorial k-NN exata via IVF (2048 centróides, k_probe=32), vetores quantizados em i16 e scan vetorizado com AVX2 (`_mm256_madd_epi16`). 3 milhões de referências pré-processadas em formato binário `RNHI` e empacotadas na imagem Docker no estágio de build.

🇺🇸 Adds participant `jfdeev-rust` at Jfdeev.json. Backend written in Rust with hyper, exact k-NN vector search via IVF (2048 centroids, k_probe=32), i16-quantized vectors and AVX2-vectorized scan (`_mm256_madd_epi16`). 3M references preprocessed into a binary `RNHI` format and baked into the Docker image at build time.

Repo: https://github.com/Jfdeev/rinha-backend-2026

## Checklist da submissão / Submission checklist

- [x] 🇧🇷 O total entre os serviços respeita o limite de **1 CPU** e **350MB RAM**<br>🇺🇸 Total across services respects the limit of **1 CPU** and **350MB RAM**
- [x] 🇧🇷 Backend expõe a porta **9999**<br>🇺🇸 Backend exposes port **9999**
- [x] 🇧🇷 Imagens são **linux/amd64**<br>🇺🇸 Images are **linux/amd64**
- [x] 🇧🇷 Rede em modo **bridge**<br>🇺🇸 Network mode is **bridge**
- [x] 🇧🇷 Não usa `network_mode: host` nem `privileged`<br>🇺🇸 Does not use `network_mode: host` nor `privileged`
- [x] 🇧🇷 Possui pelo menos **1 load balancer + 2 APIs**<br>🇺🇸 Has at least **1 load balancer + 2 APIs**
- [x] 🇧🇷 Seu repositório é **público** e contém as branches `main` e `submission`<br>🇺🇸 Your repository is **public** and contains branches `main` and `submission`
- [x] 🇧🇷 Branch `submission` contém na raiz docker-compose.yml e info.json<br>🇺🇸 Branch `submission` contains docker-compose.yml and info.json at repo root
