### PR TITLE
Add lemesdaniel-zig (floating-finch-zig)

### DIFF
--- a/participants/lemesdaniel.json
+++ b/participants/lemesdaniel.json
@@ -2,5 +2,9 @@
     {
         "id": "lemesdaniel-nim",
         "repo": "https://github.com/lemesdaniel/floating-finch"
+    },
+    {
+        "id": "lemesdaniel-zig",
+        "repo": "https://github.com/lemesdaniel/floating-finch-zig"
     }
 ]


### PR DESCRIPTION
Adicionando segunda submissão (versão Zig).

- **id**: \`lemesdaniel-zig\`
- **repo**: https://github.com/lemesdaniel/floating-finch-zig
- **stack**: Zig 0.14.1 + Python (preproc) + nginx + Docker
- **imagem**: \`ghcr.io/lemesdaniel/floating-finch-zig:v1\` (pública, linux/amd64)

Score local k6 oficial (Mac ARM via QEMU, 0.40 CPU): **3546**, detecção 100% (0 FP, 0 FN, 0 erros HTTP), p99 284ms. p99 limitado pelo HTTP server didático (single-thread + Connection: close); detecção idêntica à versão Nim.

Companion da submissão lemesdaniel-nim (PR #2067, já mergeada).