### PR TITLE
Add ogrodev-rdb-ultra submission

### DIFF
--- a/participants/ogrodev.json
+++ b/participants/ogrodev.json
@@ -1,4 +1,8 @@
 [{
     "id": "ogrodev-bun-c-simd",
     "repo": "https://github.com/ogrodev/rinha-de-backend-2026"
+},
+{
+    "id": "ogrodev-rdb-ultra",
+    "repo": "https://github.com/ogrodev/rdb-ultra"
 }]


### PR DESCRIPTION
Adds a second submission entry for `ogrodev`: `ogrodev-rdb-ultra`, pointing at https://github.com/ogrodev/rdb-ultra.

Stack: Rust API behind HAProxy, hour-bucketed exact KNN over an mmap'd, quantized reference subset.

The existing `ogrodev-bun-c-simd` entry is preserved.