### PR TITLE
Remove joojf Python submission

### DIFF
--- a/participants/joojf.json
+++ b/participants/joojf.json
@@ -2,9 +2,5 @@
   {
     "id": "joojf-rust",
     "repo": "https://github.com/joojf/rinha-2026"
-  },
-  {
-    "id": "joojf-sabor-python",
-    "repo": "https://github.com/joojf/rinha-2026-python"
   }
 ]


### PR DESCRIPTION
## Descrição / Description

Remove a submissão `joojf-sabor-python` de `participants/joojf.json`.

A submissão `joojf-rust` permanece registrada.
