### PR TITLE
add lucasgoveia participant

### DIFF
--- a/participants/lucasgoveia.json
+++ b/participants/lucasgoveia.json
@@ -1,0 +1,4 @@
+[{
+    "id": "rust-ivf",
+    "repo": "https://github.com/lucasgoveia/rinha-2026"
+}]


### PR DESCRIPTION
Adds participant entry for lucasgoveia.

- id: rust-ivf
- repo: https://github.com/lucasgoveia/rinha-2026 (now public)

Stack: Rust + HAProxy. Backend uses inverted-file (IVF) k-NN with AVX2+FMA SIMD, dim-major centroid layout, and block-strided i16 quantized vectors over 3M reference points.