### PR TITLE
rerun: lucasgoveia rust-ivf

### DIFF
--- a/participants/lucasgoveia.json
+++ b/participants/lucasgoveia.json
@@ -1,4 +1,6 @@
-[{
-    "id": "rust-ivf",
-    "repo": "https://github.com/lucasgoveia/rinha-2026"
-}]
+[
+    {
+        "id": "rust-ivf",
+        "repo": "https://github.com/lucasgoveia/rinha-2026"
+    }
+]


### PR DESCRIPTION
Rerun smoke test for lucasgoveia/rust-ivf.

- repo: https://github.com/lucasgoveia/rinha-2026 (now public)
- image: docker.io/lucasgoveia/rinha-2026:latest (linux/amd64)
- stack: Rust + HAProxy
- branches: main + submission both present, submission docker-compose uses public Docker Hub image

Previous PR was opened while source repo was private. Repo is now public so smoke test can pull source.

## Submission checklist
- [x] Total across services respects 1 CPU / 350MB RAM
- [x] Backend exposes port 9999
- [x] Images are linux/amd64
- [x] Network mode is bridge
- [x] Does not use network_mode: host nor privileged
- [x] At least 1 load balancer + 2 APIs
- [x] Repository is public, has main and submission branches
- [x] Submission branch has docker-compose.yml and info.json at repo root