### PR TITLE
add krymancer (krymancer-ocaml)

### DIFF
--- a/participants/krymancer.json
+++ b/participants/krymancer.json
@@ -1,0 +1,4 @@
+[{
+    "id": "krymancer-ocaml",
+    "repo": "https://github.com/krymancer/rinha-de-backend-2026-ocaml"
+}]


### PR DESCRIPTION
Adds `participants/krymancer.json` with one submission:

- **id**: `krymancer-ocaml`
- **repo**: https://github.com/krymancer/rinha-de-backend-2026-ocaml
- **stack**: OCaml 5 (httpaf + lwt) + nginx
- **approach**: IVF-flat kNN over a `mmap`'d binary index built offline from `references.json.gz`

Repo has MIT license, `info.json` on `main`, and a `submission` branch with the deploy files.