### PR TITLE
fix(participants/steixeira93): correct id and repo URL

### DIFF
--- a/participants/steixeira93.json
+++ b/participants/steixeira93.json
@@ -1,4 +1,4 @@
 [{
-    "id": "steixeira93-go-hnsw",
-    "repo": "https://github.com/steixeira93/rinha-backend-26"
+    "id": "steixeira93-bun-rust",
+    "repo": "https://github.com/steixeira93/rinha-backend-26-bun"
 }]


### PR DESCRIPTION
The previously merged `participants/steixeira93.json` had stale values:

- `id` was `steixeira93-go-hnsw` — but my submission is **Bun + Rust (FFI)**, not Go.
- `repo` pointed to `https://github.com/steixeira93/rinha-backend-26` (which doesn't exist anymore). The actual public repo is `https://github.com/steixeira93/rinha-backend-26-bun`.

Updating both so the engine clones the right repo and shows the right stack identifier.