### PR TITLE
Add pedrosakuma GPU brute force submission

### DIFF
--- a/participants/pedrosakuma.json
+++ b/participants/pedrosakuma.json
@@ -2,5 +2,9 @@
   {
     "id": "pedrosakuma-dotnet",
     "repo": "https://github.com/pedrosakuma/rinha-backend-2026"
+  },
+  {
+    "id": "pedrosakuma-gpu-bruteforce",
+    "repo": "https://github.com/pedrosakuma/rinha-backend-2026-gpu-bruteforce"
   }
 ]


### PR DESCRIPTION
Adds the pedrosakuma-gpu-bruteforce backend entry to participants/pedrosakuma.json.\n\nRepository: https://github.com/pedrosakuma/rinha-backend-2026-gpu-bruteforce