### PR TITLE
Add steixeira93-zig-v2 submission

### DIFF
--- a/participants/steixeira93.json
+++ b/participants/steixeira93.json
@@ -1,4 +1,6 @@
-[{
-    "id": "steixeira93-go-hnsw",
-    "repo": "https://github.com/steixeira93/rinha-backend-26"
-}]
+[
+    {
+        "id": "steixeira93-zig-v2",
+        "repo": "https://github.com/steixeira93/rinha-backend-26-v2"
+    }
+]


### PR DESCRIPTION
Adds the V2 Zig submission (binary quant + io_uring API + custom Zig LB) to my participants entry. Source: https://github.com/steixeira93/rinha-backend-26-v2