### PR TITLE
Restore steixeira93-go-hnsw entry (separate Go submission)

### DIFF
--- a/participants/steixeira93.json
+++ b/participants/steixeira93.json
@@ -2,5 +2,9 @@
     {
         "id": "steixeira93-zig-v2",
         "repo": "https://github.com/steixeira93/rinha-backend-26-v2"
+    },
+    {
+        "id": "steixeira93-go-hnsw",
+        "repo": "https://github.com/steixeira93/rinha-backend-26"
     }
 ]


### PR DESCRIPTION
PR #3009 ("Add steixeira93-zig-v2 submission") replaced `participants/steixeira93.json` with a single-element array, dropping the existing `steixeira93-go-hnsw` registration.

Both submissions are mine and live in distinct repos. Restoring the `go-hnsw` entry alongside `zig-v2` so both can be tested:

```json
[
    { "id": "steixeira93-zig-v2", "repo": "https://github.com/steixeira93/rinha-backend-26-v2" },
    { "id": "steixeira93-go-hnsw", "repo": "https://github.com/steixeira93/rinha-backend-26" }
]
```

Note: PR #3003 in the queue claims `rinha-backend-26` doesn't exist and that the project isn't Go — that PR is incorrect. The repo exists, is public, is Go, and has an active `submission` branch ready for testing. Closing #3003 in tandem.