### PR TITLE
Add participant: mpraes with rinha-2026-python2 submission

### DIFF
--- a/participants/mpraes.json
+++ b/participants/mpraes.json
@@ -1,4 +1,6 @@
-[{
-    "id": "rinha-2026-python1",
-    "repo": "https://github.com/mpraes/rinha-2026-python1"
-}]
+[
+  {
+    "id": "mpraes-python-faiss",
+    "repo": "https://github.com/mpraes/rinha-2026-python2"
+  }
+]


### PR DESCRIPTION
This PR corrects the previous submission entry to point to the rinha-2026-python2 repository instead of python1.

**Participant:** mpraes  
**Submission ID:** mpraes-python-faiss  
**Repository:** https://github.com/mpraes/rinha-2026-python2

The submission uses FAISS for approximate vector search with LRU cache for fraud detection.