### PR TITLE
add: steixeira93-bun-rust (Bun + Rust FFI, IVF block index)

### DIFF
--- a/participants/steixeira93.json
+++ b/participants/steixeira93.json
@@ -6,5 +6,9 @@
     {
         "id": "steixeira93-go-hnsw",
         "repo": "https://github.com/steixeira93/rinha-backend-26"
+    },
+    {
+        "id": "steixeira93-bun-rust",
+        "repo": "https://github.com/steixeira93/rinha-backend-26-bun"
     }
 ]


### PR DESCRIPTION
Adds a third entry to my participants file for the Bun + Rust FFI submission, alongside the existing Go and Zig entries.

- `steixeira93-bun-rust` → https://github.com/steixeira93/rinha-backend-26-bun

Stack: Bun on the HTTP layer + Rust dynamic library via `bun:ffi` for KNN math. IVF (K=4096) + bbox SIMD pruning + block-packed layout + borderline exact pass for 100% detection at the decision boundary. ~88 MB index fits within the per-container 160 MB cgroup limit.

Image: `ghcr.io/steixeira93/fraud-api:latest` (public, `linux/amd64`).

Existing entries (`steixeira93-go-hnsw`, `steixeira93-zig-v2`) are unchanged.