### PR TITLE
Fix mpraes submission IDs to match test runner format

### DIFF
--- a/participants/mpraes.json
+++ b/participants/mpraes.json
@@ -1,10 +1,10 @@
 [
   {
-    "id": "mpraes-python2",
+    "id": "rinha-2026-python2",
     "repo": "https://github.com/mpraes/rinha-2026-python2"
   },
   {
-    "id": "mpraes-python1",
+    "id": "rinha-2026-python1",
     "repo": "https://github.com/mpraes/rinha-2026-python1"
   }
 ]


### PR DESCRIPTION
## Description
Fixes submission ID format mismatch that was preventing tests from running.

## Changes
- Updated submission IDs from `mpraes-python1`/`mpraes-python2` to `rinha-2026-python1`/`rinha-2026-python2`
- IDs now match the format expected by the test automation system when issue comments trigger tests

## Related Issues
#3259 #3258

## Testing
Tests should now run successfully when triggered with `rinha/test rinha-2026-python1` or `rinha/test rinha-2026-python2` comments