### PR TITLE
add jovinull-zig submission

### DIFF
--- a/participants/Jovinull.json
+++ b/participants/Jovinull.json
@@ -2,5 +2,9 @@
   {
     "id": "jovinull-rust",
     "repo": "https://github.com/jovinull/rinha-2026-rust"
+  },
+  {
+    "id": "jovinull-zig",
+    "repo": "https://github.com/Jovinull/rinha-2026-zig"
   }
 ]


### PR DESCRIPTION
Adiciona o backend em Zig ao meu arquivo de participantes.

- `id`: `jovinull-zig`
- `repo`: https://github.com/Jovinull/rinha-2026-zig

Stack: Zig 0.13 + io_uring + UDS + IVF6 K=2048 (k-NN quantizado) + HAProxy round-robin.