### PR TITLE
participants: update mpraes submission IDs

### DIFF
--- a/participants/mpraes.json
+++ b/participants/mpraes.json
@@ -1,6 +1,10 @@
 [
   {
-    "id": "mpraes-python-faiss",
+    "id": "rinha-2026-python2",
     "repo": "https://github.com/mpraes/rinha-2026-python2"
+  },
+  {
+    "id": "rinha-2026-python1",
+    "repo": "https://github.com/mpraes/rinha-2026-python1"
   }
 ]


### PR DESCRIPTION
## Summary
Update `participants/mpraes.json` to use the submission IDs expected by the test runner and include both repositories.

## Changes
- Replace legacy id `mpraes-python-faiss`
- Add:
  - `rinha-2026-python2` -> https://github.com/mpraes/rinha-2026-python2
  - `rinha-2026-python1` -> https://github.com/mpraes/rinha-2026-python1

This PR only changes participant metadata.
