### PR TITLE
add muanlartins

### DIFF
--- a/participants/muanlartins.json
+++ b/participants/muanlartins.json
@@ -1,0 +1,6 @@
+[
+    {
+        "id": "muanlartins-go",
+        "repo": "https://github.com/muanlartins/rinha-de-backend-2026"
+    }
+]


### PR DESCRIPTION
## Descrição / Description

Adds `participants/muanlartins.json` registering one backend (`muanlartins-go`) at https://github.com/muanlartins/rinha-de-backend-2026.

Stack: Go + HAProxy. Algorithm: int16-quantized 32-partition grid index over the 3M reference vectors with axis-aligned-bbox lower-bound cell pruning and early-exit squared-distance kernel. Repo is public, MIT-licensed, has `main` (source) and `submission` (compose + haproxy.cfg + info.json) branches.

## Submission checklist

- [x] 🇺🇸 Total across services respects the limit of **1 CPU** and **350MB RAM** (0.10 + 0.45 + 0.45 = 1.00 CPU; 15 + 167 + 167 = 349 MB)
- [x] 🇺🇸 Backend exposes port **9999** (HAProxy)
- [x] 🇺🇸 Images are **linux/amd64**
- [x] 🇺🇸 Network mode is **bridge**
- [x] 🇺🇸 Does not use `network_mode: host` nor `privileged`
- [x] 🇺🇸 Has at least **1 load balancer + 2 APIs**
- [x] 🇺🇸 Repository is **public** and contains branches `main` and `submission`
- [x] 🇺🇸 Branch `submission` contains `docker-compose.yml` and `info.json` at repo root