### PR TITLE
add sschonss-rust submission

### DIFF
--- a/participants/sschonss.json
+++ b/participants/sschonss.json
@@ -1,4 +1,8 @@
 [{
     "id": "sschonss-php-swoole",
     "repo": "https://github.com/sschonss/rinha-de-backend-2026"
+},
+{
+    "id": "sschonss-rust",
+    "repo": "https://github.com/sschonss/rinha-de-backend-2026-rust"
 }]


### PR DESCRIPTION
Adiciona segunda submissão (Rust + monoio + io_uring) usando o mesmo kernel C de busca vetorial. Repo: https://github.com/sschonss/rinha-de-backend-2026-rust