### PR TITLE
feat: add participant oliveirajhony-zig

### DIFF
--- a/participants/oliveirajhony.json
+++ b/participants/oliveirajhony.json
@@ -2,5 +2,9 @@
   {
     "id": "oliveirajhony-rust",
     "repo": "https://github.com/oliveirajhony/rinhabackend-2026-rust"
+  },
+  {
+    "id": "oliveirajhony-zig",
+    "repo": "https://github.com/oliveirajhony/rinhabackend-2026-zig"
   }
 ]


### PR DESCRIPTION
Submissao em Zig. IVF (K=4096) com centroids `i16` SoA + bbox `i16`, kernel SIMD `i16/i32` com acumulador `u32` em halves (sem overflow), adaptive fallback `{1..4}` com bbox-prune nos dois tiers, io_uring API + epoll TCP→UDS LB.

- Repo: https://github.com/oliveirajhony/rinhabackend-2026-zig
- Branch `submission` ja contem `docker-compose.yml`, `info.json` e `LICENSE`
- 0% FP/FN no preview oficial (`test/test-data.json`), p99 ~1.24ms