### PR TITLE
Add italovinicius18 as a participant

### DIFF
--- a/participants/italovinicius18.json
+++ b/participants/italovinicius18.json
@@ -1,0 +1,6 @@
+[
+    {
+        "id": "italovinicius18-rinha-ai",
+        "repo": "https://github.com/italovinicius18/rinha-ai-2026-ignore"
+    }
+]


### PR DESCRIPTION
Adding `participants/italovinicius18.json`.

- **id**: `italovinicius18-rinha-ai`
- **repo**: https://github.com/italovinicius18/rinha-ai-2026-ignore
- **stack**: pure Go (stdlib `net/http`) + HAProxy 2.9

The repo is public and the `submission` branch is live with pre-built Docker Hub images (`italovinicius18/rinha-2026-api:v1` + `italovinicius18/rinha-2026-data-prep:v1`).