### PR TITLE
Add luan-louzada-v3 participant

### DIFF
--- a/participants/luanlouzada.json
+++ b/participants/luanlouzada.json
@@ -2,5 +2,9 @@
   {
     "id": "luan-louzada",
     "repo": "https://github.com/luanlouzada/rinha_backend2026"
+  },
+  {
+    "id": "luan-louzada-v3",
+    "repo": "https://github.com/luanlouzada/rinha_backend2026_v3"
   }
 ]


### PR DESCRIPTION
Adds a second participant entry for the v3 backend repository.\n\nRepo: https://github.com/luanlouzada/rinha_backend2026_v3\nID: luan-louzada-v3