### PR TITLE
Add italovinicius18 variant entries (np5, cpu, deep)

### DIFF
--- a/participants/italovinicius18.json
+++ b/participants/italovinicius18.json
@@ -2,5 +2,17 @@
     {
         "id": "italovinicius18-rinha-ai",
         "repo": "https://github.com/italovinicius18/rinha-ai-2026-ignore"
+    },
+    {
+        "id": "italovinicius18-rinha-ai-np5",
+        "repo": "https://github.com/italovinicius18/rinha-ai-2026-np5"
+    },
+    {
+        "id": "italovinicius18-rinha-ai-cpu",
+        "repo": "https://github.com/italovinicius18/rinha-ai-2026-cpu"
+    },
+    {
+        "id": "italovinicius18-rinha-ai-deep",
+        "repo": "https://github.com/italovinicius18/rinha-ai-2026-deep"
     }
 ]


### PR DESCRIPTION
Adds three config variants to my existing participants entry. Same Docker Hub
images (`italovinicius18/rinha-2026-{api,data-prep}:v1`), only the `docker-compose.yml`
env / CPU split differs between repos.

| id | NPROBE | haproxy CPU | api CPU each | repo |
|---|:-:|:-:|:-:|---|
| italovinicius18-rinha-ai-np5 | 5 | 0.15 | 0.40 | rinha-ai-2026-np5 |
| italovinicius18-rinha-ai-cpu | 6 | 0.10 | 0.425 | rinha-ai-2026-cpu |
| italovinicius18-rinha-ai-deep | 8 | 0.10 | 0.425 | rinha-ai-2026-deep |

Each repo's `submission` branch is already live with the correct
`docker-compose.yml`, `haproxy.cfg`, `info.json`, and `README.md`.