### PR TITLE
participants: add rinha-2026-python3 submission for mpraes

### DIFF
--- a/participants/mpraes.json
+++ b/participants/mpraes.json
@@ -1,5 +1,9 @@
 [
   {
+    "id": "rinha-2026-python3",
+    "repo": "https://github.com/mpraes/rinha-2026-python3"
+  },
+  {
     "id": "rinha-2026-python2",
     "repo": "https://github.com/mpraes/rinha-2026-python2"
   },


### PR DESCRIPTION
## Summary
Add submission entry to participants/mpraes.json.

## Changes
- Add rinha-2026-python3 -> https://github.com/mpraes/rinha-2026-python3

## Submission checklist
- [x] Total across services respects the limit of 1 CPU and 350MB RAM
- [x] Backend exposes port 9999
- [x] Images are linux/amd64
- [x] Network mode is bridge
- [x] Does not use network_mode: host nor privileged
- [x] Has at least 1 load balancer + 2 APIs
- [x] Repository is public and contains branches main and submission
- [x] Branch submission contains docker-compose.yml and info.json at repo root