### PR TITLE
Adiciona psavelis (Rust + io_uring + IVF)

### DIFF
--- a/participants/psavelis.json
+++ b/participants/psavelis.json
@@ -1,0 +1,6 @@
+[
+  {
+    "id": "psavelis-rust-iouring-ivf",
+    "repo": "https://github.com/psavelis/rinha-backend-2026"
+  }
+]


### PR DESCRIPTION
Submissão de Pedro Savelis para a Rinha de Backend 2026.

## Stack

- Rust estável.
- Servidor HTTP em `io_uring` cru: single issuer, defer taskrun, coop taskrun, uma só thread por instância, slots de conexão pré-alocados, sem async/await.
- HAProxy 3.0 (alpine) em `mode tcp` com `splice`, round-robin sobre Unix Domain Sockets.
- HTTP/1.1 e JSON parseados à mão, sem alocação no caminho quente.
- Índice IVF próprio (formato v2): 4096 centróides, `nprobe=1`, vetores quantizados em `i16` no layout SoA, bounding boxes por cluster para descarte por limite inferior, varredura com early exit por dimensão, kernel AVX2+FMA escrito à mão.
- `index.bin` (~92 MB) mapeado com `mmap(MAP_SHARED | MAP_POPULATE)` e `mlock`'d; o page cache do kernel deduplica as páginas físicas entre as duas APIs.

## Recursos

Dentro do limite agregado de 1 CPU e 350 MB: HAProxy 0.10/30M, api-1 e api-2 com 0.45/160M cada.

## Resultados verificados

A CI roda o teste oficial do k6 a cada push em um runner native linux/amd64. Últimas execuções: score 6000, p99 entre 0.50 e 0.81 ms, zero falsos positivos, zero falsos negativos, zero erros HTTP sobre 162.000 requisições por execução.

## Repositório

https://github.com/psavelis/rinha-backend-2026

Imagem: `ghcr.io/psavelis/rinha-backend-2026:latest` (linux/amd64).