### PR TITLE
add viniciusdsandrade rust submission

### DIFF
--- a/participants/viniciusdsandrade.json
+++ b/participants/viniciusdsandrade.json
@@ -2,5 +2,9 @@
     {
         "id": "andrade-cpp-ivf",
         "repo": "https://github.com/viniciusdsandrade/rinha-de-backend-2026"
+    },
+    {
+        "id": "andrade-rust-ivf",
+        "repo": "https://github.com/viniciusdsandrade/rinha-de-backend-2026-rust"
     }
 ]


### PR DESCRIPTION
Adiciona a submissão paralela `andrade-rust-ivf` apontando para o repositório público Rust.

Escopo: somente `participants/viniciusdsandrade.json`.