### PR TITLE
Add jonathanperis asm submission

### DIFF
--- a/participants/jonathanperis.json
+++ b/participants/jonathanperis.json
@@ -6,5 +6,9 @@
   {
     "id": "jonathanperis-c",
     "repo": "https://github.com/jonathanperis/rinha4-back-end-c"
+  },
+  {
+    "id": "jonathanperis-asm",
+    "repo": "https://github.com/jonathanperis/rinha4-yolo-mode"
   }
 ]


### PR DESCRIPTION
Adds Jonathan Peris' pure x86-64 assembly/YOL0-mode participant repo.

The participant repository is public, MIT licensed, and has a compose-only `submission` branch with pinned GHCR images.
