### PR TITLE
add participant: lucasmenchon-c

### DIFF
--- a/participants/lucasmenchon.json
+++ b/participants/lucasmenchon.json
@@ -1,0 +1,4 @@
+[{
+    "id": "lucasmenchon-c",
+    "repo": "https://github.com/lucasmenchon/rinha-de-backend-2026-c"
+}]


### PR DESCRIPTION
Adding participant file for lucasmenchon-c — pure C backend with IVF+AVX2 vector search, FD-passing LB.

- Repo: https://github.com/lucasmenchon/rinha-de-backend-2026-c
- Stack: C, epoll, SCM\_RIGHTS fd-passing, IVF index, AVX2
- License: MIT