### PR TITLE
participants: include mpraes python2 and python3

### DIFF
--- a/participants/mpraes.json
+++ b/participants/mpraes.json
@@ -1,5 +1,13 @@
 [
   {
+    "id": "mpraes-python3",
+    "repo": "https://github.com/mpraes/rinha-2026-python3"
+  },
+  {
+    "id": "mpraes-python2",
+    "repo": "https://github.com/mpraes/rinha-2026-python2"
+  },
+  {
     "id": "mpraes-python1",
     "repo": "https://github.com/mpraes/rinha-2026-python1"
   }


### PR DESCRIPTION
Mantém as três submissões do participante mpraes no arquivo participants/mpraes.json:
- mpraes-python1 -> rinha-2026-python1
- mpraes-python2 -> rinha-2026-python2
- mpraes-python3 -> rinha-2026-python3

Isso evita perder as entradas python2/python3.