### PR TITLE
fix: align mpraes submission IDs with requested pattern

### DIFF
--- a/participants/mpraes.json
+++ b/participants/mpraes.json
@@ -1,14 +1,14 @@
 [
   {
-    "id": "mpraes-python3",
+    "id": "rinha-2026-python3",
     "repo": "https://github.com/mpraes/rinha-2026-python3"
   },
   {
-    "id": "mpraes-python2",
+    "id": "rinha-2026-python2",
     "repo": "https://github.com/mpraes/rinha-2026-python2"
   },
   {
-    "id": "mpraes-python1",
+    "id": "rinha-2026-python1",
     "repo": "https://github.com/mpraes/rinha-2026-python1"
   }
 ]


### PR DESCRIPTION
Os IDs das submissões em participants/mpraes.json foram alterados para rinha-2026-python1/2/3 para alinhar com o padrão solicitado.