### PR TITLE
participants: add claudin.io-swift to Tavernari

### DIFF
--- a/participants/Tavernari.json
+++ b/participants/Tavernari.json
@@ -1,4 +1,8 @@
 [{
     "id": "claudinio-swift",
     "repo": "https://github.com/claudin-io/rinha-de-backend-2026"
+},
+{
+    "id": "claudin.io-swift",
+    "repo": "https://github.com/claudin-io/rinha-de-backend-2026"
 }]


### PR DESCRIPTION
## Descrição / Description

Adicionando segunda entry ao `Tavernari.json` com o ID `claudin.io-swift` apontando para o mesmo repositório.

O ID anterior (`claudinio-swift`) parou de funcionar — os resultados dos testes pararam de aparecer após o repositório de origem ser recriado ([#5836](https://github.com/zanfranceschi/rinha-de-backend-2026/issues/5836)).

The previous ID (`claudinio-swift`) stopped working — test results stopped appearing after the source repository was recreated. This adds a new entry with ID `claudin.io-swift` pointing to the same repository.

## Checklist da submissão / Submission checklist

- [x] O total entre os serviços respeita o limite de **1 CPU** e **350MB RAM**
- [x] Backend expõe a porta **9999**
- [x] Imagens são **linux/amd64**
- [x] Rede em modo **bridge**
- [x] Não usa `network_mode: host` nem `privileged`
- [x] Possui pelo menos **1 load balancer + 2 APIs**
- [x] Seu repositório é **público** e contém as branches `main` e `submission`
- [x] Branch `submission` contém na raiz `docker-compose.yml` e `info.json`