### PR TITLE
participants: add geeksilva97-cpp

### DIFF
--- a/participants/geeksilva97.json
+++ b/participants/geeksilva97.json
@@ -2,5 +2,9 @@
   {
     "id": "geeksilva97-ruby-ivf",
     "repo": "https://github.com/geeksilva97/rinha-2026"
+  },
+  {
+    "id": "geeksilva97-cpp",
+    "repo": "https://github.com/geeksilva97/rinha-cpp"
   }
 ]


### PR DESCRIPTION
Adds a second backend entry for `geeksilva97`: **`geeksilva97-cpp`** — a full-C++ rewrite of the existing `geeksilva97-ruby-ivf` submission.

- Repo: https://github.com/geeksilva97/rinha-cpp
- Submission branch: https://github.com/geeksilva97/rinha-cpp/tree/submission
- Image: `docker.io/codesilva/rinha-cpp@sha256:356e9103ecc0dd5baf1c0aabb3b87803145e954bc8b4e7223994fe5f421206c2` (linux/amd64, public)

Stack: hand-rolled epoll HTTP server, SCM_RIGHTS load balancer (out of the data path after fd handoff), int16-quantized IVF kNN with AVX2 distance kernel. Existing Ruby submission stays unchanged.