### PR TITLE
Add otto (Odin) — thales-maciel

### DIFF
--- a/participants/thales-maciel.json
+++ b/participants/thales-maciel.json
@@ -6,5 +6,9 @@
     {
         "id": "thales-maciel-haskell",
         "repo": "https://github.com/thales-maciel/helheim"
+    },
+    {
+        "id": "thales-maciel-odin",
+        "repo": "https://github.com/thales-maciel/otto"
     }
 ]


### PR DESCRIPTION
Adds a third backend to `participants/thales-maciel.json`: **otto**, an Odin implementation (alongside the existing zordon/Zig and helheim/Haskell entries).

- Repo: https://github.com/thales-maciel/otto
- Stack: Odin + nginx
- Exact 5-NN over the 3M reference vectors via an i16-quantized KD-tree; hand-rolled epoll HTTP/1.1 server with precomputed responses. `main` has the source; `submission` has the run files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)