### PR TITLE
Fix molBR participant id casing

### DIFF
--- a/participants/molBR.json
+++ b/participants/molBR.json
@@ -1,4 +1,4 @@
 [{
-    "id": "molbr",
+    "id": "molBR",
     "repo": "https://github.com/molBR/rinha-backend-2026"
 }]


### PR DESCRIPTION
Fix `id` field casing from `molbr` to `molBR` so preview tests can resolve the submission.