### PR TITLE
Add Pongelupe participant

### DIFF
--- a/participants/Pongelupe.json
+++ b/participants/Pongelupe.json
@@ -1,0 +1,6 @@
+[
+  {
+    "id": "pongelupe-rust",
+    "repo": "https://github.com/Pongelupe/rinha-backend-2026"
+  }
+]


### PR DESCRIPTION
Adding participants/Pongelupe.json for rinha-de-backend-2026 submission.

- Repo: https://github.com/Pongelupe/rinha-backend-2026
- Stack: Rust + nginx, custom IVF-Flat ANN
- ID: pongelupe-rust