### PR TITLE
rename marcioomonte id: typescript -> rust

### DIFF
--- a/participants/marcioomonte.json
+++ b/participants/marcioomonte.json
@@ -1,6 +1,6 @@
 [
     {
-        "id": "marcioomonte-typescript",
+        "id": "marcioomonte-rust",
         "repo": "https://github.com/marcioomonte/rinha-de-backend-2026"
     }
 ]


### PR DESCRIPTION
The backend was migrated from TypeScript+HNSW to Rust+IVF. Renaming the submission id to reflect the actual stack.