### PR TITLE
Adiciona submissão Java de luccarhaddad

### DIFF
--- a/participants/luccarhaddad.json
+++ b/participants/luccarhaddad.json
@@ -1,1 +1,4 @@
-[{"id": "luccarhaddad-zig", "repo": "https://github.com/luccarhaddad/luccarhaddad-zig-rb26"}]
+[
+    {"id": "luccarhaddad-zig", "repo": "https://github.com/luccarhaddad/luccarhaddad-zig-rb26"},
+    {"id": "luccarhaddad-java", "repo": "https://github.com/luccarhaddad/rinha-2026-java"}
+]


### PR DESCRIPTION
Adicionando minha segunda submissão (em Java) ao arquivo `participants/luccarhaddad.json`.

- Repo: https://github.com/luccarhaddad/rinha-2026-java
- Branch `submission`: https://github.com/luccarhaddad/rinha-2026-java/tree/submission
- Imagem pública: https://hub.docker.com/r/luccarhaddad/rinha2026-java (linux/amd64)
- Licença MIT

Mantive a entrada existente (`luccarhaddad-zig`) intacta.