### PR TITLE
Add d3vk1ng1337 Zig submission

### DIFF
--- a/participants/d3vk1ng1337.json
+++ b/participants/d3vk1ng1337.json
@@ -1,1 +1,8 @@
-[{"id":"d3vk1ng1337","repo":"https://github.com/d3vk1ng1337/rinha-backend-26-zero"}]
+[{
+  "id": "d3vk1ng1337",
+  "repo": "https://github.com/d3vk1ng1337/rinha-backend-26-zero"
+},
+{
+  "id": "d3vk1ng1337-zig",
+  "repo": "https://github.com/d3vk1ng1337/rinha-backend-26-v2"
+}]


### PR DESCRIPTION
Adds the migrated Zig submission repository for d3vk1ng1337: https://github.com/d3vk1ng1337/rinha-backend-26-v2

Submission id: d3vk1ng1337-zig