### PR TITLE
fix: update vitortvale stack id from C++ to OCaml

### DIFF
--- a/participants/vitortvale.json
+++ b/participants/vitortvale.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "C++",
+    "id": "OCaml",
     "repo": "https://github.com/vitortvale/rinha-de-backend-2026"
   }
 ]


### PR DESCRIPTION
The participant file has `"id": "C++"` but the submission is OCaml. Updating to `"id": "OCaml"` so test runs resolve correctly.