### PR TITLE
Add participant: IthaloPS (C + IVF k-NN + FD-passing LB)

### DIFF
--- a/participants/IthaloPS.json
+++ b/participants/IthaloPS.json
@@ -1,0 +1,6 @@
+[
+  {
+    "id": "ithalops-c-ivf",
+    "repo": "https://github.com/IthaloPS/rinha-fraud-2026"
+  }
+]


### PR DESCRIPTION
Adds my participation file `participants/IthaloPS.json`.

- **Stack:** C (no framework), single-thread epoll server + custom FD-passing load balancer (SCM_RIGHTS over unix sockets).
- **Vector search:** IVF (k-means, K=4096) over 3M int16-quantized vectors, AVX2 integer distance; 0% decision disagreement vs exact k-NN in calibration.
- **Repo:** https://github.com/IthaloPS/rinha-fraud-2026 (MIT, `main` + `submission` branches).

Resource budget: 1 CPU / 350 MB total (api1 0.35/165MB, api2 0.35/165MB, lb 0.30/20MB).

Made with [Cursor](https://cursor.com)