### PR TITLE
Add gogoncalves-mojo submission

### DIFF
--- a/participants/gogoncalves.json
+++ b/participants/gogoncalves.json
@@ -6,5 +6,9 @@
     {
         "id": "gogoncalves-go",
         "repo": "https://github.com/gogoncalves/rinha-go-2026"
+    },
+    {
+        "id": "gogoncalves-mojo",
+        "repo": "https://github.com/gogoncalves/rinha-mojo-2026"
     }
 ]


### PR DESCRIPTION
## Summary
- Adds `gogoncalves-mojo` entry to `participants/gogoncalves.json`.
- Source repo: https://github.com/gogoncalves/rinha-mojo-2026

## Test plan
- [x] `info.json` valid, repo public
- [x] `docker-compose.yml` smoke/stress validated locally