### PR TITLE
Add krymancer-zig submission

### DIFF
--- a/participants/krymancer.json
+++ b/participants/krymancer.json
@@ -1,4 +1,10 @@
-[{
-    "id": "krymancer-ocaml",
-    "repo": "https://github.com/krymancer/rinha-de-backend-2026-ocaml"
-}]
+[
+    {
+        "id": "krymancer-ocaml",
+        "repo": "https://github.com/krymancer/rinha-de-backend-2026-ocaml"
+    },
+    {
+        "id": "krymancer-zig",
+        "repo": "https://github.com/krymancer/rinha-de-backend-2026-zig"
+    }
+]


### PR DESCRIPTION
Adds the `krymancer-zig` backend: a Zig implementation using exact int16 kd-tree k-NN (provably E=0) with an SCM_RIGHTS fd-passing load balancer.

Repo: https://github.com/krymancer/rinha-de-backend-2026-zig (public, MIT, has `main` + `submission` branches).