### PR TITLE
Enroll: bentoplebstguida (Go + nginx)

### DIFF
--- a/participants/bentoplebstguida.json
+++ b/participants/bentoplebstguida.json
@@ -1,4 +1,4 @@
 [{
-    "id": "bento-go-nginx",
+    "id": "bento-go-nginx-optim-6000",
     "repo": "https://github.com/bentoplebstguida/rinha-de-backend-2026"
 }]

--- a/participants/bentoplebstguida.json
+++ b/participants/bentoplebstguida.json
@@ -1,0 +1,4 @@
+[{
+    "id": "bento-go-nginx",
+    "repo": "https://github.com/bentoplebstguida/rinha-de-backend-2026"
+}]


### PR DESCRIPTION
Enrolling bentoplebstguida in Rinha de Backend 2026.

Repo with submission: https://github.com/bentoplebstguida/rinha-de-backend-2026
Branch with submission files: submission
Stack: go + nginx
Optimizations: network_mode host, proxy_buffering on, 0.50 CPU per API, reuseport, keepalive 512