### PR TITLE
Enroll: bentoplebstguida (Go + nginx, optim-6000) [conflict-resolved]

### DIFF
--- a/participants/bentoplebstguida.json
+++ b/participants/bentoplebstguida.json
@@ -1,4 +1,4 @@
 [{
-    "id": "bento-go-nginx",
+    "id": "bento-go-nginx-optim-6000",
     "repo": "https://github.com/bentoplebstguida/rinha-de-backend-2026"
 }]

--- a/participants/bentoplebstguida.json
+++ b/participants/bentoplebstguida.json
@@ -1,0 +1,4 @@
+[{
+    "id": "bento-go-nginx",
+    "repo": "https://github.com/bentoplebstguida/rinha-de-backend-2026"
+}]


### PR DESCRIPTION
Resolves add/add conflict in participants/bentoplebstguida.json.

PR #8649 had the right content but couldn't auto-merge because both branches modified the same file. This PR uses the fork's version (with id bento-go-nginx-optim-6000) which points to the optim-6000 submission.

Smoke test passed (PR #8649 confirmed this).

Source code repo: https://github.com/bentoplebstguida/rinha-de-backend-2026
Branch: submission
Stack: go + nginx
Optimizations: proxy_buffering on, 0.50 CPU per API, keepalive 512, reuseport
Bench CI: p99 0.523ms, score 6000