### PR TITLE
Add gb-zig submission

### DIFF
--- a/participants/gb.json
+++ b/participants/gb.json
@@ -1,4 +1,8 @@
 [{
     "id": "gb-a-jvm-and-a-dream",
     "repo": "https://github.com/gb/jvmoonshot-xxvi"
+},
+{
+    "id": "gb-zig",
+    "repo": "https://github.com/gb/rinha-zig"
 }]


### PR DESCRIPTION
Adds a second submission entry (`gb-zig`) to `participants/gb.json`.